### PR TITLE
Convert README to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
-Snort++
+# Snort++
 
-The Snort++ project has been hard at work for a while now and we are
-finally ready to release the first alpha of the next generation Snort IPS
-(Intrusion Prevention System).  This file will show you what Snort++ has to
-offer and guide you through the steps from download to demo.  If you are
-unfamiliar with Snort you should take a look at the Snort documentation
-first.  We will cover the following topics:
+>The Snort++ project has been hard at work for a while now and we are
+>finally ready to release the first alpha of the next generation Snort IPS
+>(Intrusion Prevention System).  This file will show you what Snort++ has to
+>offer and guide you through the steps from download to demo.  If you are
+>unfamiliar with Snort you should take a look at the Snort documentation
+>first. We will cover the following topics:
 
-* Overview
-* Dependencies
-* Download
-* Build Snort
-* Run Snort
-* Documentation
-* Squeal
+---
 
-OVERVIEW
+* [Overview](#overview)
+* [Dependencies](#dependencies)
+* [Download](#download)
+* [Build Snort](#build-snort)
+* [Run Snort](#run-snort)
+* [Documentation](#documentation)
+* [Squeal](#squeal)
+
+# OVERVIEW
 
 This first alpha release is based on early Snort 2.9.6 and excludes all but
 one of Snort's dynamic preprocessors (ftp_telnet).  Work is underway to
@@ -48,7 +50,7 @@ Additional features on the roadmap include:
 * Simplify memory management
 * Provide all of Snort's functionality
 
-DEPENDENCIES
+# DEPENDENCIES
 
 If you already build Snort, you may have everything you need.  If not, grab
 the latest:
@@ -63,7 +65,7 @@ the latest:
 * zlib from http://www.zlib.net for decompression
 * pkgconfig from http://www.freedesktop.org to build the example plugins
 
-DOWNLOAD
+# DOWNLOAD
 
 There are two source tarballs, once for autotools and one for cmake:
 
@@ -74,100 +76,123 @@ You can also git the code with:
 
     git clone git://github.com/snortadmin/snort3.git
 
-BUILD SNORT
+# BUILD SNORT
 
 Follow these steps:
 
 1.  Set up source directory:
 
-* If you are using a github clone:
+  * If you are using a github clone:
 
+    ```shell 
     cd snort3/
+    ```
 
-* Otherwise, do this:
+  * Otherwise, do this:
 
+    ```shell
     tar zxf snort-tarball
     cd snort-3.0.0*
+    ```
+    
+1.  Setup install path:
 
-2.  Setup install path:
-
+    ```shell
     export my_path=/path/to/snorty
+    ```
 
-3.  Compile and install:
+1.  Compile and install:
 
-* To build with autotools, simply do the usual from the top level directory:
+  * To build with autotools, simply do the usual from the top level directory:
 
+    ```shell 
     ./configure --prefix=$my_path
     make -j 8 install
+    ```
+    
+  * To build with cmake and make, run configure_cmake.sh.  It will automatically create and populate a new subdirectory named 'build'.
 
-* To build with cmake and make, run configure_cmake.sh.  It will
-  automatically create and populate a new subdirectory named 'build'.
-
+    ```shell
     ./configure_cmake.sh --prefix=$my_path
     cd build
     make -j 8 install
+    ```
 
-Note:
+**_Note_**:
 
-* If you are using autotools with a github clone, first do autoreconf -isvf.
-* If you can do src/snort -V you built successfully.
-* If you are familiar with cmake, you can run cmake/ccmake instead of
-  configure_cmake.sh.
-* cmake --help will list any available generators, such as Xcode.  Feel
-  free to use one, however help with those will be provided separately.
+  * If you are using autotools with a github clone, first do autoreconf -isvf.
+  * If you can do src/snort -V you built successfully.
+  * If you are familiar with cmake, you can run cmake/ccmake instead of configure_cmake.sh.
+  * cmake --help will list any available generators, such as Xcode.  Feel free to use one, however help with those will be provided separately.
 
-RUN SNORT
+# RUN SNORT
 
 First set up the environment:
 
-    export LUA_PATH=$my_path/include/snort/lua/\?.lua\;\;
-    export SNORT_LUA_PATH=$my_path/etc/snort
+```shell
+export LUA_PATH=$my_path/include/snort/lua/\?.lua\;\;
+export SNORT_LUA_PATH=$my_path/etc/snort
+```
 
 Then give it a go:
 
 * Snort++ provides lots of help from the command line.  Here are some examples:
 
+    ```shell
     $my_path/bin/snort --help
     $my_path/bin/snort --help-module suppress
     $my_path/bin/snort --help-config | grep thread
+    ```
 
 * Examine and dump a pcap.  In the following, replace a.pcap with your
   favorite:
 
+    ```shell
     $my_path/bin/snort -r a.pcap
     $my_path/bin/snort -K text -d -e -q -r a.pcap
+    ```
 
 * Verify a config, with or w/o rules:
 
+    ```shell
     $my_path/bin/snort -c $my_path/etc/snort/snort.lua
     $my_path/bin/snort -c $my_path/etc/snort/snort.lua -R $my_path/etc/snort/sample.rules
+    ```
 
 * Run IDS mode.  In the following, replace pcaps/ with a path to a directory
   with one or more *.pcap files:
 
+    ```shell
     $my_path/bin/snort -c $my_path/etc/snort/snort.lua -R $my_path/etc/snort/sample.rules \
         -r a.pcap -A alert_test -n 100000
+    ```
 
 * Let's suppress 1:2123.  We could edit the conf or just do this:
 
+    ```shell
     $my_path/bin/snort -c $my_path/etc/snort/snort.lua -R $my_path/etc/snort/sample.rules \
         -r a.pcap -A alert_test -n 100000 --lua "suppress = { { gid = 1, sid = 2123 } }"
+    ```
 
 * Go whole hog on a directory with multiple packet threads:
 
+    ```shell
     $my_path/bin/snort -c $my_path/etc/snort/snort.lua -R $my_path/etc/snort/sample.rules \
         --pcap-filter \*.pcap --pcap-dir pcaps/ -A alert_fast --max-packet-threads 8
+    ```
 
 Additional examples are given in doc/usage.txt.
 
-DOCUMENTATION
+# DOCUMENTATION
 
 Take a look at the manual, parts of which are generated by the code so it
 stays up to date:
 
-    $my_path/share/doc/snort/snort_manual.pdf
-    $my_path/share/doc/snort/snort_manual.html
-    $my_path/share/doc/snort/snort_manual/index.html
+```shell
+$my_path/share/doc/snort/snort_manual.pdf
+$my_path/share/doc/snort/snort_manual.html
+$my_path/share/doc/snort/snort_manual/index.html
+```
 
 It does not yet have much on the how and why, but it does have all the
 currently available configuration, etc.  Some key changes to rules:
@@ -187,7 +212,8 @@ It also covers new features not demonstrated here:
 * improved rule parsing - arbitrary whitespace, C style comments, #begin/#end comments
 * local and remote command line shell
 
-SQUEAL o")~
+# SQUEAL 
+`o")~`
 
 We hope you are as excited about Snort++ as we are.  Although a lot of work
 remains, we wanted to give you a chance to try it out and let us know what


### PR DESCRIPTION
This change beautifies the project README file. 
 
- Add `md` file extension so that github will treat the file like a markdown file.
 - Add formatted project header
 - Add table of contents
 - Add markdown to delimit sections properly
 - Update code samples with proper language name and '`' wrappers.