### PR TITLE
snort_defaults.lua: No such file or directory

### DIFF
--- a/lua/snort.lua
+++ b/lua/snort.lua
@@ -12,7 +12,7 @@
 --
 -- then:
 -- export LUA_PATH=$DIR/include/snort/lua/?.lua\;\;
--- export SNORT_LUA_PATH=$DIR/conf/
+-- export SNORT_LUA_PATH=$DIR/etc/snort
 ---------------------------------------------------------------------------
 
 ---------------------------------------------------------------------------


### PR DESCRIPTION
snort_defaults.lua and file_magic.lua are located in $DIR/etc/snort.