### PR TITLE
Update file_policy.cc

### DIFF
--- a/src/file_api/file_policy.cc
+++ b/src/file_api/file_policy.cc
@@ -84,8 +84,10 @@ void FilePolicy::insert_file_rule(FileRule& rule)
     }
 
     // Enable file type for all other features
-    FileService::enable_file_type();
-    type_enabled = true;
+    if (rule.use.type_enabled) {
+        FileService::enable_file_type();
+        type_enabled = true;
+    }
 
     if (rule.use.signature_enabled)
         FileService::enable_file_signature();


### PR DESCRIPTION
file type is always enabled and not follow the setup in snort.lua. It will cause that signature check only apply to type defined file.