### PR TITLE
Hyperscan: use hs_valid_platform() to test host support

### DIFF
--- a/cmake/FindHS.cmake
+++ b/cmake/FindHS.cmake
@@ -10,6 +10,6 @@ find_library(HS_LIBRARIES NAMES hs
     HINTS ${HS_LIBRARIES_DIR} ${PC_HYPERSCAN_LIBDIR} ${PC_HYPERSCAN_LIBRARY_DIRS})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(HS DEFAULT_MSG HS_LIBRARIES HS_INCLUDE_DIRS)
+find_package_handle_standard_args(HS REQUIRED_VARS HS_LIBRARIES HS_INCLUDE_DIRS VERSION_VAR PC_HYPERSCAN_VERSION)
 
 mark_as_advanced(HS_INCLUDE_DIRS HS_LIBRARIES)

--- a/cmake/include_libraries.cmake
+++ b/cmake/include_libraries.cmake
@@ -19,6 +19,6 @@ find_package(LibLZMA QUIET)
 find_package(Asciidoc QUIET)
 find_package(DBLATEX QUIET)
 find_package(Ruby QUIET 1.8.7)
-find_package(HS QUIET)
+find_package(HS QUIET 4.4.0)
 find_package(SafeC QUIET)
 

--- a/configure.ac
+++ b/configure.ac
@@ -944,8 +944,8 @@ LIBS="$LIBS -lz"
 # hyperscan (optional)
 #--------------------------------------------------------------------------
 
-AC_MSG_CHECKING([for hyperscan pkg-config presence])
-PKG_CHECK_EXISTS([libhs], [ have_hyperscan_pkgconfig="yes" ], [ have_hyperscan_pkgconfig="no" ])
+AC_MSG_CHECKING([for hyperscan >= 4.4.0 pkg-config presence])
+PKG_CHECK_EXISTS([libhs >= 4.4.0], [ have_hyperscan_pkgconfig="yes" ], [ have_hyperscan_pkgconfig="no" ])
 AC_MSG_RESULT(${have_hyperscan_pkgconfig})
 
 HYPERSCAN_CPPFLAGS=""

--- a/src/ips_options/ips_regex.cc
+++ b/src/ips_options/ips_regex.cc
@@ -289,6 +289,12 @@ bool RegexModule::set(const char*, Value& v, SnortConfig*)
 
 bool RegexModule::end(const char*, int, SnortConfig*)
 {
+    if ( hs_valid_platform() != HS_SUCCESS )
+    {
+        ParseError("This host does not support Hyperscan.");
+        return false;
+    }
+
     hs_compile_error_t* err = nullptr;
 
     if ( hs_compile(config.re.c_str(), config.pmd.flags, HS_MODE_BLOCK, nullptr, &config.db, &err)

--- a/src/ips_options/ips_sd_pattern.cc
+++ b/src/ips_options/ips_sd_pattern.cc
@@ -368,6 +368,12 @@ bool SdPatternModule::set(const char*, Value& v, SnortConfig* sc)
 
 bool SdPatternModule::end(const char*, int, SnortConfig*)
 {
+    if ( hs_valid_platform() != HS_SUCCESS )
+    {
+        ParseError("This host does not support Hyperscan.");
+        return false;
+    }
+
     hs_compile_error_t* err = nullptr;
 
     if ( hs_compile(config.pii.c_str(), HS_FLAG_DOTALL|HS_FLAG_SOM_LEFTMOST, HS_MODE_BLOCK,

--- a/src/search_engines/hyperscan.cc
+++ b/src/search_engines/hyperscan.cc
@@ -208,6 +208,12 @@ void HyperscanMpse::user_dtor()
 
 int HyperscanMpse::prep_patterns(SnortConfig* sc)
 {
+    if ( hs_valid_platform() != HS_SUCCESS )
+    {
+        ParseError("This host does not support Hyperscan.");
+        return -1;
+    }
+
     hs_compile_error_t* errptr = nullptr;
     std::vector<const char*> pats;
     std::vector<unsigned> flags;


### PR DESCRIPTION
Versions of [Hyperscan ](https://01.org/hyperscan) >= 4.4.0 have the function `hs_valid_platform()`, which can be used to query whether the host has the architecture features required to use Hyperscan (e.g. `SSSE3`).

This patch set uses this function (on recent enough Hyperscan versions) to make a Snort binary built with Hyperscan support fail gracefully if the system does not have the required features.