### PR TITLE
Fix IPv6 Flow Label

### DIFF
--- a/src/protocols/ipv6.h
+++ b/src/protocols/ipv6.h
@@ -86,7 +86,7 @@ struct IP6Hdr
     { return (uint16_t)((ntohl(ip6_vtf) & 0x0FF00000) >> 20); }
 
     inline uint32_t flow() const
-    { return (uint16_t)((ntohl(ip6_vtf) & 0x000FFFFF) >> 20); }
+    { return (ntohl(ip6_vtf) & 0x000FFFFF); }
 
     // because Snort expects this in terms of 32 bit words.
     inline uint8_t hlen() const


### PR DESCRIPTION
This fixes the ipv6 flow() function. Currently it is always returning 0.
The shift operation isn't needed, because the flow label already is already at the lower 20 bits of vtf.