### PR TITLE
Add RUSAGE_SELF in CPUTracker::get_clocks

### DIFF
--- a/src/network_inspectors/perf_monitor/cpu_tracker.cc
+++ b/src/network_inspectors/perf_monitor/cpu_tracker.cc
@@ -73,8 +73,10 @@ void CPUTracker::get_clocks(struct timeval& user_time,
     struct rusage usage;
 #ifdef RUSAGE_LWP
     getrusage(RUSAGE_LWP, &usage);
-#else
+#elif defined(RUSAGE_THREAD)
     getrusage(RUSAGE_THREAD, &usage);
+#else
+    getrusage(RUSAGE_SELF, &usage);
 #endif
     user_time = usage.ru_utime;
     sys_time = usage.ru_stime;


### PR DESCRIPTION
RUSAGE_THREAD it only available on linux, so use RUSAGE_SELF if
RUSAGE_THREAD is undefined

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>