### PR TITLE
Fix snort linking

### DIFF
--- a/src/network_inspectors/port_scan/CMakeLists.txt
+++ b/src/network_inspectors/port_scan/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library( port_scan
+add_library( port_scan STATIC
     port_scan.cc
     ps_detect.cc
     ps_detect.h


### PR DESCRIPTION
Add STATIC to add_library call of port_scan to build it statically
otherwise link will fail (Makefile.am already build only the static
version)

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>