### PR TITLE
Fix snort2lua linking

### DIFF
--- a/tools/snort2lua/config_states/CMakeLists.txt
+++ b/tools/snort2lua/config_states/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library( config_states
+add_library( config_states STATIC
     config_alertfile.cc
     config_binding.cc
     config_checksums.cc

--- a/tools/snort2lua/data/CMakeLists.txt
+++ b/tools/snort2lua/data/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_subdirectory (data_types)
 
-add_library( conversion_data
+add_library( conversion_data STATIC
     dt_data.h
     dt_data.cc
     dt_table_api.h

--- a/tools/snort2lua/data/data_types/CMakeLists.txt
+++ b/tools/snort2lua/data/data_types/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library( data_types
+add_library( data_types STATIC
     dt_comment.h
     dt_comment.cc
     dt_include.h

--- a/tools/snort2lua/helpers/CMakeLists.txt
+++ b/tools/snort2lua/helpers/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library( snort2lua_helpers
+add_library( snort2lua_helpers STATIC
     converter.h
     converter.cc
     s2l_util.h

--- a/tools/snort2lua/keyword_states/CMakeLists.txt
+++ b/tools/snort2lua/keyword_states/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library( keyword_states
+add_library( keyword_states STATIC
     kws_attribute_table.cc
     kws_config.cc
     kws_deleted.cc

--- a/tools/snort2lua/output_states/CMakeLists.txt
+++ b/tools/snort2lua/output_states/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(output_states
+add_library(output_states STATIC
     out_csv.cc
     out_deleted.cc
     out_fast.cc

--- a/tools/snort2lua/preprocessor_states/CMakeLists.txt
+++ b/tools/snort2lua/preprocessor_states/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(preprocessor_states
+add_library(preprocessor_states STATIC
     pps_appid.cc
     pps_arpspoof.cc
     pps_bo.cc

--- a/tools/snort2lua/rule_states/CMakeLists.txt
+++ b/tools/snort2lua/rule_states/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library( rule_states
+add_library( rule_states STATIC
     rule_base64_decode.cc
     rule_content.cc
     rule_convert_comma_list.cc


### PR DESCRIPTION
Add STATIC to all add_library calls of snort2lua libraries to build them
statically otherwise link will fail (Makefile.am already builds only the
static version)

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>