### PR TITLE
Update CMake config to use GNUInstallDirs and match automake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,11 @@ set (VERSION_BUILD 0)
 set (VERSION
     "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}")
 
+# Pull in definitions of various install directories
+include(GNUInstallDirs)
+
 set (INCLUDE_SUFFIX "${CMAKE_PROJECT_NAME}")
-set (INCLUDE_INSTALL_PATH "include/${INCLUDE_SUFFIX}")
+set (INCLUDE_INSTALL_PATH "${CMAKE_INSTALL_INCLUDEDIR}/${INCLUDE_SUFFIX}")
 
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/cmake/create_options.cmake
+++ b/cmake/create_options.cmake
@@ -63,7 +63,3 @@ set (
     SIGNAL_SNORT_READ_ATTR_TBL "SIGURG"
     CACHE STRING "set the SNORT_READ_ATTR_TBL signal (must be a valid integer or signal name)"
 )
-
-#Setting default directories...appended to INSTALL_PREFIX unless a full path is provided
-set ( SNORT_DATA_DIR share/doc/${CMAKE_PROJECT_NAME} )
-

--- a/cmake/create_pkg_config.cmake
+++ b/cmake/create_pkg_config.cmake
@@ -5,7 +5,7 @@
 set(prefix "${CMAKE_INSTALL_PREFIX}")
 set(exec_prefix "\${prefix}")
 set(bindir "\${exec_prefix}/bin")
-set(libdir "\${exec_prefix}/lib")
+set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
 set(includedir "\${prefix}/include")
 set(datarootdir "\${prefix}/share")
 set(datadir "\${datarootdir}")
@@ -69,5 +69,5 @@ configure_file(
 )
 
 install (FILES ${CMAKE_BINARY_DIR}/snort.pc
-    DESTINATION "lib/pkgconfig/"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/"
 )

--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -24,7 +24,7 @@ macro (add_dynamic_module libname install_path)
     install (
         TARGETS ${libname}
         LIBRARY
-            DESTINATION "lib/${CMAKE_PROJECT_NAME}/${install_path}"
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/${install_path}"
     )
 endmacro (add_dynamic_module)
 

--- a/cmake/platforms.cmake
+++ b/cmake/platforms.cmake
@@ -11,7 +11,6 @@ endif()
 
 set (CMAKE_SKIP_RPATH ON)
 
-
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8")
         message(FATAL_ERROR "G++ version 4.8 or greater required")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -315,7 +315,7 @@ install (
     ${BUILT_DIST}
     ${UNBUILT_SOURCES}
     DESTINATION
-    ${SNORT_DATA_DIR}
+    ${CMAKE_INSTALL_DOCDIR}
 )
 
 set (

--- a/extra/src/codecs/cd_eapol/CMakeLists.txt
+++ b/extra/src/codecs/cd_eapol/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS cd_eapol
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/codecs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/codecs"
 )

--- a/extra/src/codecs/cd_linux_sll/CMakeLists.txt
+++ b/extra/src/codecs/cd_linux_sll/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS cd_linux_sll
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/codecs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/codecs"
 )

--- a/extra/src/codecs/cd_null/CMakeLists.txt
+++ b/extra/src/codecs/cd_null/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS cd_null
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/codecs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/codecs"
 )

--- a/extra/src/codecs/cd_pbb/CMakeLists.txt
+++ b/extra/src/codecs/cd_pbb/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS cd_pbb
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/codecs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/codecs"
 )

--- a/extra/src/codecs/cd_pflog/CMakeLists.txt
+++ b/extra/src/codecs/cd_pflog/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS cd_pflog
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/codecs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/codecs"
 )

--- a/extra/src/codecs/cd_ppp/CMakeLists.txt
+++ b/extra/src/codecs/cd_ppp/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS cd_ppp
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/codecs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/codecs"
 )

--- a/extra/src/codecs/cd_raw4/CMakeLists.txt
+++ b/extra/src/codecs/cd_raw4/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS cd_raw4
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/codecs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/codecs"
 )

--- a/extra/src/codecs/cd_raw6/CMakeLists.txt
+++ b/extra/src/codecs/cd_raw6/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS cd_raw6
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/codecs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/codecs"
 )

--- a/extra/src/codecs/cd_slip/CMakeLists.txt
+++ b/extra/src/codecs/cd_slip/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS cd_slip
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/codecs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/codecs"
 )

--- a/extra/src/codecs/cd_token_ring/CMakeLists.txt
+++ b/extra/src/codecs/cd_token_ring/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS cd_token_ring
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/codecs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/codecs"
 )

--- a/extra/src/codecs/cd_wlan/CMakeLists.txt
+++ b/extra/src/codecs/cd_wlan/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS cd_wlan
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/codecs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/codecs"
 )

--- a/extra/src/daqs/daq_regtest/CMakeLists.txt
+++ b/extra/src/daqs/daq_regtest/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS daq_regtest
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/daqs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/daqs"
 )

--- a/extra/src/daqs/daq_socket/CMakeLists.txt
+++ b/extra/src/daqs/daq_socket/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS daq_socket
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/daqs"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/daqs"
 )

--- a/extra/src/inspectors/data_log/CMakeLists.txt
+++ b/extra/src/inspectors/data_log/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS data_log
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/inspectors"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/inspectors"
 )

--- a/extra/src/inspectors/dpx/CMakeLists.txt
+++ b/extra/src/inspectors/dpx/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS dpx
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/inspectors"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/inspectors"
 )

--- a/extra/src/inspectors/reg_test/CMakeLists.txt
+++ b/extra/src/inspectors/reg_test/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS reg_test
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/inspectors"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/inspectors"
 )

--- a/extra/src/ips_options/find/CMakeLists.txt
+++ b/extra/src/ips_options/find/CMakeLists.txt
@@ -3,5 +3,5 @@ project ( find )
 
 install (
     FILES find.lua
-    DESTINATION "lib/${CMAKE_PROJECT_NAME}/ips_options"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/ips_options"
 )

--- a/extra/src/ips_options/ips_mss/CMakeLists.txt
+++ b/extra/src/ips_options/ips_mss/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS ips_mss
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/ips_options"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/ips_options"
 )

--- a/extra/src/ips_options/ips_pkt_num/CMakeLists.txt
+++ b/extra/src/ips_options/ips_pkt_num/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS ips_pkt_num
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/ips_options"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/ips_options"
 )

--- a/extra/src/ips_options/ips_urg/CMakeLists.txt
+++ b/extra/src/ips_options/ips_urg/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS ips_urg
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/ips_options"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/ips_options"
 )

--- a/extra/src/ips_options/ips_wscale/CMakeLists.txt
+++ b/extra/src/ips_options/ips_wscale/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS ips_wscale
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/ips_options"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/ips_options"
 )

--- a/extra/src/loggers/alert_ex/CMakeLists.txt
+++ b/extra/src/loggers/alert_ex/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS alert_ex
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/loggers"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/loggers"
 )

--- a/extra/src/loggers/alert_json/CMakeLists.txt
+++ b/extra/src/loggers/alert_json/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS alert_json
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/loggers"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/loggers"
 )

--- a/extra/src/loggers/alert_lua/CMakeLists.txt
+++ b/extra/src/loggers/alert_lua/CMakeLists.txt
@@ -3,5 +3,5 @@ project ( alert_lua )
 
 install (
     FILES alert.lua
-    DESTINATION "lib/${CMAKE_PROJECT_NAME}/loggers"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/loggers"
 )

--- a/extra/src/loggers/alert_unixsock/CMakeLists.txt
+++ b/extra/src/loggers/alert_unixsock/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS alert_unixsock
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/loggers"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/loggers"
 )

--- a/extra/src/loggers/log_null/CMakeLists.txt
+++ b/extra/src/loggers/log_null/CMakeLists.txt
@@ -37,5 +37,5 @@ target_include_directories (
 install (
     TARGETS log_null
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/loggers"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/loggers"
 )

--- a/extra/src/search_engines/lowmem/CMakeLists.txt
+++ b/extra/src/search_engines/lowmem/CMakeLists.txt
@@ -40,5 +40,5 @@ target_include_directories (
 install (
     TARGETS lowmem
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/search_engines"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/search_engines"
 )

--- a/extra/src/so_rules/sid_18758/CMakeLists.txt
+++ b/extra/src/so_rules/sid_18758/CMakeLists.txt
@@ -38,5 +38,5 @@ target_include_directories (
 install (
     TARGETS sid_18758
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/so_rules"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/so_rules"
 )

--- a/extra/templates/CMakeLists.txt.erb
+++ b/extra/templates/CMakeLists.txt.erb
@@ -48,13 +48,13 @@ target_include_directories (
 install (
     TARGETS <%= @project.libname %>
     LIBRARY
-        DESTINATION "lib/${CMAKE_PROJECT_NAME}/<%= @project.dirname %>"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/<%= @project.dirname %>"
 )
 %end
 %if !@project.scripts.empty?
 
 install (
     FILES<% for script in @project.scripts %> <%= script %><% end %>
-    DESTINATION "lib/${CMAKE_PROJECT_NAME}/<%= @project.dirname %>"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}/<%= @project.dirname %>"
 )
 %end

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -6,5 +6,5 @@ set (LUA_SCRIPTS
 )
 
 install (FILES ${LUA_SCRIPTS}
-    DESTINATION "etc/snort"
+    DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/snort"
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -197,10 +197,10 @@ set_target_properties(
 
 install (TARGETS snort
     EXPORT snortexe
-    RUNTIME DESTINATION bin
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 install (EXPORT snortexe
-    DESTINATION lib/snort
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/snort
     FILE snort.cmake
 )

--- a/tools/flatbuffers/CMakeLists.txt
+++ b/tools/flatbuffers/CMakeLists.txt
@@ -12,7 +12,7 @@ if ( FLATBUFFERS_FOUND )
     )
 
     install (TARGETS fbstreamer
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 endif()
 

--- a/tools/snort2lua/CMakeLists.txt
+++ b/tools/snort2lua/CMakeLists.txt
@@ -33,5 +33,5 @@ target_link_libraries( snort2lua
 )
 
 install (TARGETS snort2lua
-    RUNTIME DESTINATION bin
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/tools/u2boat/CMakeLists.txt
+++ b/tools/u2boat/CMakeLists.txt
@@ -13,9 +13,9 @@ target_link_libraries( u2boat
 )
 
 install (TARGETS u2boat
-    RUNTIME DESTINATION bin
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 install(FILES README.u2boat
-    DESTINATION "${SNORT_DATA_DIR}"
+    DESTINATION "${CMAKE_INSTALL_DOCDIR}"
 )

--- a/tools/u2spewfoo/CMakeLists.txt
+++ b/tools/u2spewfoo/CMakeLists.txt
@@ -10,6 +10,6 @@ target_include_directories( u2spewfoo
 )
 
 install (TARGETS u2spewfoo
-    RUNTIME DESTINATION bin
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 


### PR DESCRIPTION
There is a disparity between the automake + CMake build systems in terms of install directories which are used, causing problems when building for distributions like Debian with multiarch'd library directories. This changeset includes the GNUInstallDirs module in the CMake config and updates the install paths as appropriate to correct this.