### PR TITLE
Allow use of ARM64 CNTVCT_EL0 register for TSC_CLOCK

### DIFF
--- a/src/time/tsc_clock.h
+++ b/src/time/tsc_clock.h
@@ -48,9 +48,17 @@ struct TscClock
 
     static uint64_t counter()
     {
+#if defined(__aarch64__)
+        uint64_t ticks;
+
+        asm volatile("mrs %0, CNTVCT_EL0" : "=r" (ticks));
+        return ticks;
+#else
+        // Default to x86, other archs will compile error anyway
         uint32_t lo, hi;
         asm volatile("rdtsc" : "=a" (lo), "=d" (hi));
         return ((uint64_t)hi << 32) | lo;
+#endif
     }
 
     static time_point now() noexcept


### PR DESCRIPTION
This changeset enables the use of CNTVCT_EL0 on ARM64 platforms to a performance boost in the same way as rdtsc on x86 platforms when ENABLE_TSC_CLOCK is set. Testing indicates up to 10% performance improvement as a result on an A53 platform.